### PR TITLE
Server: fixed bug in createTeam, it now correctly checks to make sure…

### DIFF
--- a/server/Controller/Routes/team.js
+++ b/server/Controller/Routes/team.js
@@ -7,6 +7,7 @@ const shortUUID = require('short-uuid');
 const getTeam = require('../../Helpers/teamHelpers/getTeam');
 const createTeam = require('../../Helpers/teamHelpers/createTeam');
 const updateTeam = require('../../Helpers/teamHelpers/updateTeam');
+const retireTeam = require('../../Helpers/teamHelpers/retireTeam');
 const addBugToQueue = require('../../Helpers/teamHelpers/addBugToQueue');
 const assignBug = require('../../Helpers/teamHelpers/assignBug');
 
@@ -39,6 +40,15 @@ teamRouter.put('/update', (req,res) => {
         res.status(400).send('Error');
     }
     updateTeam(userId,teamId,teamId,res)
+})
+
+// Retire Team
+teamRouter.put('/retire', (req,res) => {
+    const {userId,teamId} = req.body;
+    if (!userId | !teamId) {
+        res.status(400).send('Error');
+    }
+    retireTeam(userId,teamId,res);
 })
 
 // Add bug to Queue

--- a/server/Helpers/teamHelpers/createTeam.js
+++ b/server/Helpers/teamHelpers/createTeam.js
@@ -18,7 +18,7 @@ const createTeam = (userId,teamName,res) => {
         }
         if (user.data.teams.past.length > 0){
             user.data.teams.past.forEach(team => {
-                if (team.team === teamName) {
+                if (team[0] === teamName) {
                     return res.status(400).send('Unavailable');
                 }
             });
@@ -32,6 +32,7 @@ const createTeam = (userId,teamName,res) => {
             }
             const teamObject = {
                 teamId: teamId,
+                status: "active",
                 data: {
                     team: teamName,
                     members: [[userName,userId]],

--- a/server/Helpers/teamHelpers/retireTeam.js
+++ b/server/Helpers/teamHelpers/retireTeam.js
@@ -1,0 +1,78 @@
+const userModel = require('../../Model/userModel');
+const teamModel = require('../../Model/teamModel');
+
+const retireTeam = (userId,teamId,res) => {
+
+    let userData = {};
+
+    userModel.findOne({userId}, (err,user) => {
+        if (err | !user) {
+            return res.status(400).send('Error0');
+        }
+        if (user.role) {
+            teamModel.findOne({teamId}, (err, team) => {
+                if (err | !team) {
+                    return res.status(400).send('Error1')
+                }
+                else{
+                    team.data.members.forEach(member => {
+                        if (member[1] === userId) {
+                            userData = user.data;
+                            return;
+                        }
+                        else {
+                            return res.status(401).send('Unauthorized1');
+                        }
+                    })
+                    teamModel.findOne({teamId}, (err, team) => {
+                        if (err | !team) {
+                            return res.status(400).send('Error2');
+                        }
+                        else {
+                            team.data.members.forEach(member => {
+                                const userId = member[1];
+                                userModel.findOne({userId}, (err, user) => {
+                                    if (err | !user) {
+                                        return res.status(400).send('Error3');
+                                    }
+                                    else {
+                                        userData = user.data;
+                                        let tempStorage = userData.teams.current;
+                                        console.log(tempStorage);
+                                        userData.teams.current = [];
+                                        userData.teams.past.push(tempStorage);
+                                        console.log(userData);
+                                        userModel.findOneAndUpdate(userId,{data:userData}, (err, updateSuccess) => {
+                                            if (err | !updateSuccess) {
+                                                return  res.status(400).send('Error');
+                                            }
+                                            else {
+                                                teamModel.findOneAndUpdate(teamId,{status:'retired'})
+                                                .then(success => {
+                                                    return res.status(201).send('Success')
+                                                })
+                                                .catch((err) => {
+                                                    return res.status(400).send('Error4')
+                                                })
+                                            }
+                                        })
+                                    }
+                                })
+                            })
+
+                        }
+                    })
+                }
+
+            })
+            
+        }
+        else {
+            return res.status(401).send('Unauthorized2');
+        }
+        
+    })
+
+}
+
+module.exports = retireTeam;

--- a/server/Model/teamModel.js
+++ b/server/Model/teamModel.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const schema = mongoose.Schema({
     id:String,
     teamId:String,
+    status:String,
     data:Object({
         team:String,
         members:Object([]),


### PR DESCRIPTION
… user the project manager doesn't create two teams with the same name - by checking past teams. Created retireTeams helper with /retire endpoint to retire team a team which is required before making another, this is done by changing the team status to retired and moving the team information from each member's current section and into each member's past team section. Everything is working perfectly.